### PR TITLE
fix(form): add form component tab

### DIFF
--- a/internal/ui/pages/form.templ
+++ b/internal/ui/pages/form.templ
@@ -15,9 +15,10 @@ templ Form() {
 			Tailwind:    true,
 		}) {
 			@modules.ExampleWrapper(modules.ExampleWrapperProps{
-				SectionName:     "",
-				ShowcaseFile:    showcase.InputForm(),
-				PreviewCodeFile: "input_form.templ",
+				SectionName:       "",
+				ShowcaseFile:      showcase.InputForm(),
+				PreviewCodeFile:   "input_form.templ",
+				ComponentCodeFile: "form.templ",
 			})
 			<div>
 				@components.Card(components.CardProps{}) {


### PR DESCRIPTION
The `Form` component was missing the tab where you can copy the actual component code