### PR TITLE
fix(docs): add missing `--ring` color variable in tailwind base config

### DIFF
--- a/internal/ui/pages/how_to_use.templ
+++ b/internal/ui/pages/how_to_use.templ
@@ -73,6 +73,7 @@ var inputCss = `@import 'tailwindcss';
   --color-popover-foreground: hsl(var(--popover-foreground));
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
+  --color-ring: hsl(var(--ring));
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -427,3 +428,4 @@ templ HowToUse() {
 		</div>
 	}
 }
+


### PR DESCRIPTION
`ring-ring` did not respect the theme if you changed it from the base one