### PR TITLE
Add HxReplaceUrl to ButtonProps

### DIFF
--- a/components/button.templ
+++ b/components/button.templ
@@ -31,25 +31,26 @@ const (
 
 // ButtonProps configures the Button component
 type ButtonProps struct {
-	Class      string           // Additional CSS classes
-	Text       string           // Button label text
-	Variant    ButtonVariant    // Visual style
-	Size       ButtonSize       // Button dimensions
-	FullWidth  bool             // Expand to fill container
-	Href       string           // URL for link buttons
-	Target     string           // Link target attribute
-	Disabled   bool             // Interactivity state
-	Type       string           // Button type attribute
-	IconLeft   templ.Component  // Icon component before text
-	IconRight  templ.Component  // Icon component after text
-	HxGet      string           // HTMX: URL for GET requests
-	HxPost     string           // HTMX: URL for POST requests
-	HxPut      string           // HTMX: URL for PUT requests
-	HxDelete   string           // HTMX: URL for DELETE requests
-	HxTrigger  string           // HTMX: Trigger event
-	HxTarget   string           // HTMX: Target for response
-	HxSwap     string           // HTMX: Method for inserting response
-	Attributes templ.Attributes // Additional HTML attributes
+	Class        string           // Additional CSS classes
+	Text         string           // Button label text
+	Variant      ButtonVariant    // Visual style
+	Size         ButtonSize       // Button dimensions
+	FullWidth    bool             // Expand to fill container
+	Href         string           // URL for link buttons
+	Target       string           // Link target attribute
+	Disabled     bool             // Interactivity state
+	Type         string           // Button type attribute
+	IconLeft     templ.Component  // Icon component before text
+	IconRight    templ.Component  // Icon component after text
+	HxGet        string           // HTMX: URL for GET requests
+	HxPost       string           // HTMX: URL for POST requests
+	HxPut        string           // HTMX: URL for PUT requests
+	HxDelete     string           // HTMX: URL for DELETE requests
+	HxTrigger    string           // HTMX: Trigger event
+	HxTarget     string           // HTMX: Target for response
+	HxSwap       string           // HTMX: Method for inserting response
+	HxReplaceUrl string           // HTMX: Replace the URL to - (alternative to using Href, to void reloading the page)
+	Attributes   templ.Attributes // Additional HTML attributes
 }
 
 // variantClasses returns CSS classes based on button variant
@@ -178,6 +179,9 @@ templ Button(props ButtonProps) {
 			}
 			if props.HxSwap != "" {
 				hx-swap={ props.HxSwap }
+			}
+			if props.HxReplaceUrl != "" {
+				hx-replace-url={ props.HxReplaceUrl }
 			}
 		>
 			{ children... }


### PR DESCRIPTION
Hello 

With this PR proposal i would like to introduce the hx-replace-url button property. 
You already have a wide htmx compatibility which is great, but one thing which bothers me, is that the replace-url property is not there.
As of now you have two options to change the URL per button click. 

1. Use Href -> this will force a page reload, it gets the job done, but you break the htmx flow
2. Use the Attributes property -> Just more boiler plate for the solution i now propose. 

I would really appreciate if this finds the way into the next release :)