### PR TITLE
Add Alpine based tooltip

### DIFF
--- a/components/tooltipAlpine.templ
+++ b/components/tooltipAlpine.templ
@@ -1,0 +1,90 @@
+package components
+
+import (
+	"fmt"
+	"github.com/axzilla/templui/utils"
+)
+
+type ATooltipProps struct {
+	Text      string          // Text which is displayed insided the tooltip
+	Trigger   templ.Component // The trigger of the tooltip
+	Side      TooltipSide     // Tooltip position relative to trigger
+	ShowArrow bool            // Whether to show the arrow pointer
+	Variant   TooltipVariant  // Visual style variant
+	Class     string          // Additional CSS classes
+
+}
+
+func getDataFromProps(props ATooltipProps) string {
+	// Set default side of tooltip
+	side := TooltipTop
+	if props.Side != "" {
+		side = props.Side
+	}
+
+	return fmt.Sprintf("{tooltipVisible: false,tooltipText: '%v',tooltipArrow: %t,tooltipPosition: '%v'}", props.Text, props.ShowArrow, side)
+}
+
+func getAlpineArrowClass(side TooltipSide) string {
+	switch side {
+	case TooltipRight:
+		return "left-0 -translate-y-1/2 top-1/2 h-2.5 -mt-px -translate-x-full"
+	case TooltipBottom:
+		return "top-0 -translate-x-1/2 left-1/2 w-2.5 -translate-y-full"
+	case TooltipLeft:
+		return "right-0 -translate-y-1/2 top-1/2 h-2.5 -mt-px translate-x-full"
+	default:
+		return "bottom-0 -translate-x-1/2 left-1/2 w-2.5 translate-y-full" // Top
+	}
+}
+
+func getAlpineTooltipSideClass(side TooltipSide) string {
+	switch side {
+	case TooltipRight:
+		return "top-1/2 -translate-y-1/2 -mr-1 right-0 translate-x-full"
+	case TooltipBottom:
+		return "bottom-0 left-1/2 -translate-x-1/2 -mb-1 translate-y-full"
+	case TooltipLeft:
+		return "top-1/2 -translate-y-1/2 -ml-1 left-0 -translate-x-full"
+	default:
+		return "top-0 left-1/2 -translate-x-1/2 -mt-1 -translate-y-full" //top
+	}
+}
+
+templ TTooltip(props ATooltipProps) {
+	<div
+		x-data={ getDataFromProps(props) }
+		x-init="$refs.content.addEventListener('mouseenter', () => { tooltipVisible = true; }); $refs.content.addEventListener('mouseleave', () => { tooltipVisible = false; });"
+		class="relative"
+	>
+		<div
+			x-ref="tooltip"
+			x-show="tooltipVisible"
+			class={ utils.TwMerge("absolute w-auto text-sm z-50", getTooltipSideClass(props.Side)) }
+			x-cloak
+		>
+			<div
+				x-show="tooltipVisible"
+				x-transition
+				class={ utils.TwMerge(
+			"relative px-2 py-1 rounded bg-opacity-90 ",
+			getTooltipVariantClass(props.Variant)) }
+			>
+				<p x-text="tooltipText" class="flex-shrink-0 block text-xs whitespace-nowrap"></p>
+				<div
+					x-ref="tooltipArrow"
+					x-show="tooltipArrow"
+					class={ utils.TwMerge("absolute inline-flex items-center justify-center overflow-hidden", getArrowClass(props.Side)) }
+				>
+					<div
+						:class="{ 'origin-top-left -rotate-45' : tooltipPosition == 'top', 'origin-top-left rotate-45' : tooltipPosition == 'left', 'origin-bottom-left rotate-45' : tooltipPosition == 'bottom', 'origin-top-right -rotate-45' : tooltipPosition == 'right' }"
+						class={ utils.TwMerge("w-1.5 h-1.5 transform bg-black bg-opacity-90", getArrowColor(props.Variant)) }
+					></div>
+				</div>
+			</div>
+		</div>
+		<div x-ref="content">
+			@props.Trigger
+		</div>
+	</div>
+}

--- a/components/tooltip_alpine.templ
+++ b/components/tooltip_alpine.templ
@@ -51,7 +51,7 @@ func getAlpineTooltipSideClass(side TooltipSide) string {
 	}
 }
 
-templ TTooltip(props ATooltipProps) {
+templ ATooltip(props ATooltipProps) {
 	<div
 		x-data={ getDataFromProps(props) }
 		x-init="$refs.content.addEventListener('mouseenter', () => { tooltipVisible = true; }); $refs.content.addEventListener('mouseleave', () => { tooltipVisible = false; });"

--- a/internal/ui/pages/tooltipAlpine.templ
+++ b/internal/ui/pages/tooltipAlpine.templ
@@ -1,0 +1,50 @@
+package pages
+
+import (
+	"github.com/axzilla/templui/internal/ui/layouts"
+	"github.com/axzilla/templui/internal/ui/modules"
+	"github.com/axzilla/templui/internal/ui/showcase"
+)
+
+templ ATooltip() {
+	@layouts.DocsLayout(
+		"Tooltip",
+		"A small pop-up box that appears when a user hovers over an element",
+	) {
+		@modules.PageWrapper(modules.PageWrapperProps{
+			Name:        "Tooltip",
+			Description: templ.Raw("A small pop-up box that appears when a user hovers over an element"),
+			Tailwind:    true,
+		}) {
+			@modules.ExampleWrapper(modules.ExampleWrapperProps{
+				ShowcaseFile:      showcase.ATooltip(),
+				PreviewCodeFile:   "tooltip_alpine.templ",
+				ComponentCodeFile: "tooltip_alpine.templ",
+			})
+			@modules.Usage(modules.UsageProps{
+				ComponentName: "Tooltip",
+				PropsExample:  "...",
+			})
+			@modules.ContainerWrapper(modules.ContainerWrapperProps{Title: "Examples"}) {
+				@modules.ExampleWrapper(modules.ExampleWrapperProps{
+					SectionName:       "Variants",
+					ShowcaseFile:      showcase.ATooltipVariants(),
+					PreviewCodeFile:   "tooltip_alpine_variants.templ",
+					ComponentCodeFile: "tooltip_alpine.templ",
+				})
+				@modules.ExampleWrapper(modules.ExampleWrapperProps{
+					SectionName:       "Sides",
+					ShowcaseFile:      showcase.ATooltipSides(),
+					PreviewCodeFile:   "tooltip_alpine_sides.templ",
+					ComponentCodeFile: "tooltip_alpine.templ",
+				})
+				@modules.ExampleWrapper(modules.ExampleWrapperProps{
+					SectionName:       "With Arrow",
+					ShowcaseFile:      showcase.ATooltipWithArrow(),
+					PreviewCodeFile:   "tooltip_alpine_with_arrow.templ",
+					ComponentCodeFile: "tooltip_alpine.templ",
+				})
+			}
+		}
+	}
+}

--- a/internal/ui/showcase/tooltip_alpine.templ
+++ b/internal/ui/showcase/tooltip_alpine.templ
@@ -1,0 +1,13 @@
+package showcase
+
+import "github.com/axzilla/templui/components"
+
+templ ATooltip() {
+	@components.ATooltip(components.ATooltipProps{
+		Trigger: components.Button(components.ButtonProps{
+			Text:    "Hover me",
+			Variant: components.ButtonVariantOutline,
+		}),
+		Text: "Default",
+	})
+}

--- a/internal/ui/showcase/tooltip_alpine_side.templ
+++ b/internal/ui/showcase/tooltip_alpine_side.templ
@@ -1,0 +1,40 @@
+package showcase
+
+import "github.com/axzilla/templui/components"
+
+templ ATooltipSides() {
+	<div class="flex flex-wrap gap-2">
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Top",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text: "Top tooltip",
+			Side: components.TooltipTop, // Its the default value but we can set it explicitly
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Right",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text: "Right tooltip",
+			Side: components.TooltipRight,
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Bottom",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text: "Bottom tooltip",
+			Side: components.TooltipBottom,
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Left",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text: "Left tooltip",
+			Side: components.TooltipLeft,
+		})
+	</div>
+}

--- a/internal/ui/showcase/tooltip_alpine_variants.templ
+++ b/internal/ui/showcase/tooltip_alpine_variants.templ
@@ -1,0 +1,32 @@
+
+package showcase
+
+import "github.com/axzilla/templui/components"
+
+templ ATooltipVariants() {
+	<div class="flex flex-wrap gap-2">
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Default",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text: "Default tooltip",
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Secondary",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text:    "Secondary tooltip",
+			Variant: components.TooltipSecondary,
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Destructive",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text:    "Destructive tooltip",
+			Variant: components.TooltipDestructive,
+		})
+	</div>
+}

--- a/internal/ui/showcase/tooltip_alpine_with_arrow.templ
+++ b/internal/ui/showcase/tooltip_alpine_with_arrow.templ
@@ -1,0 +1,45 @@
+
+package showcase
+
+import "github.com/axzilla/templui/components"
+
+templ ATooltipWithArrow() {
+	<div class="flex flex-wrap gap-2">
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Top",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text:      "Top tooltip",
+			Side:      components.TooltipTop, // Its the default value but we can set it explicitly
+			ShowArrow: true,
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Right",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text:      "Right tooltip",
+			Side:      components.TooltipRight,
+			ShowArrow: true,
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Bottom",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text:      "Bottom tooltip",
+			Side:      components.TooltipBottom,
+			ShowArrow: true,
+		})
+		@components.ATooltip(components.ATooltipProps{
+			Trigger: components.Button(components.ButtonProps{
+				Text:    "Left",
+				Variant: components.ButtonVariantOutline,
+			}),
+			Text:      "Left tooltip",
+			Side:      components.TooltipLeft,
+			ShowArrow: true,
+		})
+	</div>
+}


### PR DESCRIPTION
Hello

I would like to propose a other way of creating tooltips. I found sometimes the original tooltip has some downsides because of it only uses css. For example the if you have an fixed size width and working with overflow-auto you will run into this issue:
![image](https://github.com/user-attachments/assets/31c4a474-3c3a-45e8-bdf3-0b94aaccd3c8)
Where the size of the element overflows the width of the parent and it gets a scroll window. 
This is because the tooltip is actually there just not visible. 
Also the feedback for the enduser is a bit laggy. 

https://github.com/user-attachments/assets/898f4de6-912e-4db0-a8ee-09b89c50a511

My Idea was basically to use the [pines UI](https://devdojo.com/pines/docs/tooltip) approach and convert it into templ. 
Since you kind of require anyway alpine for some components, this come basically free. 

Just a few thoughts....

Naming, kind of a bummer i know, didn't came up with something better. 

Why 2 different Tooltip versions? - first backwards compatibility, and also the first one is more light weight. This might be helpful if bandwidth or something like this matters.

Why ATooltipProps ?
My first goal was to get completely backwards compatible so enduser can just rename all (legacy) Tooltip to ATooltip and it works. 
```golang
// something like this
// from:
@components.Tooltip(components.TooltipProps{})....

// to:
@components.ATooltip(components.TooltipProps{})....
```
Sadly the new version only allows text in side the tooltip. So i needed to change the Content to Text as a string. 

Think to have both version inside the lib is kind of cool and both have there usecases. 
