### PR TITLE
Add a Name prop to IconProps and a UseNameProp function for generating icon

### DIFF
--- a/icons/icons.go
+++ b/icons/icons.go
@@ -25,6 +25,7 @@ var iconFS embed.FS
 
 // IconProps defines the properties that can be set for an icon.
 type IconProps struct {
+	Name        string
 	Size        string
 	Color       string
 	Fill        string
@@ -45,6 +46,24 @@ func Icon(name string) func(IconProps) templ.Component {
 			return
 		})
 	}
+}
+
+// UseNameProp generates a templ.Component using IconProps.Name, with fallback to "file-question" icon.
+func UseNameProp(props IconProps) templ.Component {
+	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) (err error) {
+		var svg string
+
+		svg, err = generateSVG(props.Name, props)
+		if err != nil {
+			svg, err = generateSVG("file-question", props)
+			if err != nil {
+				return err
+			}
+		}
+		_, err = w.Write([]byte(svg))
+		return
+	})
+
 }
 
 // generateSVG creates an SVG string for the specified icon with the given properties.


### PR DESCRIPTION
Hi,

Added a function UseNameProp and  a prop "Name", 
Useful when displaying varying kinds data using config file, the Icon can be specified in config / db ...


```
<div class="flex flex-col col-sm-auto gap-2">
            for _, poi := range scheme.PrimaryData.POI {
                <p class="inline-flex items-center gap-1 whitespace-nowrap text-sm text-muted-foreground">
                    <span>@icons.UseNameProp(icons.IconProps{Name:poi.Icon, StrokeWidth:"1", Class: "size-7"}) </span>
                    <span>{poi.Value} {poi.Units}</span>
                </p>
            }
</div>
```
