### PR TITLE
set events on browser back, history.back() - refactored for new layout

### DIFF
--- a/internal/components/drawer/drawer.templ
+++ b/internal/components/drawer/drawer.templ
@@ -240,7 +240,7 @@ var handle = templ.NewOnceHandle()
 templ Script() {
 	@handle.Once() {
 		<script nonce={ templ.GetNonce(ctx) }>
-   
+
 			(function() { // IIFE
 				function initDrawer(drawer) {
 					// Get the drawer elements
@@ -249,9 +249,11 @@ templ Script() {
 					const backdrop = drawer.querySelector('[data-drawer-backdrop]');
 					const closeButtons = drawer.querySelectorAll('[data-drawer-close]');
 					const position = content?.getAttribute('data-drawer-position') || 'right';
-					
-					if (!content || !backdrop) return;
-					
+
+					if (!content || !backdrop) {
+						return;
+					}
+
 					// Set up animations based on position
 					const transitions = {
 						'left': {
@@ -282,47 +284,47 @@ templ Script() {
 
 					// Check if drawer is already initialized
 					if (drawer.dataset.drawerInitialized) {
-						return;
+						// Remove initialization flag to allow re-initialization
+						delete drawer.dataset.drawerInitialized;
 					}
-					drawer.dataset.drawerInitialized = 'true';
 
 					// Initial styles
-					content.style.transform = position === 'left' ? 'translateX(-100%)' : 
+					content.style.transform = position === 'left' ? 'translateX(-100%)' :
 											position === 'right' ? 'translateX(100%)' :
-											position === 'top' ? 'translateY(-100%)' : 
+											position === 'top' ? 'translateY(-100%)' :
 											'translateY(100%)';
 					content.style.opacity = '0';
 					backdrop.style.opacity = '0';
 					content.style.display = 'none'; // Ensure it starts hidden
 					backdrop.style.display = 'none'; // Ensure it starts hidden
-					
+
 					// Function to open the drawer
 					function openDrawer() {
 						// Display elements
 						backdrop.style.display = 'block';
 						content.style.display = 'block';
-						
+
 						// Trigger reflow
 						void content.offsetWidth;
-						
+
 						// Apply transitions
 						backdrop.style.transition = 'opacity 300ms ease-out';
 						content.style.transition = 'opacity 300ms ease-out, transform 300ms ease-out';
-						
+
 						// Animate in
 						backdrop.style.opacity = '1';
 						content.style.opacity = '1';
 						content.style.transform = 'translate(0)';
-						
+
 						// Lock body scroll
 						document.body.style.overflow = 'hidden';
-						
+
 						// Add event listeners for close actions
 						backdrop.addEventListener('click', closeDrawer);
 						document.addEventListener('keydown', handleEscKey);
 						document.addEventListener('click', handleClickAway);
 					}
-					
+
 					// Function to close the drawer
 					function closeDrawer() {
 						// Remove event listeners before animation starts
@@ -333,10 +335,10 @@ templ Script() {
 						// Apply transitions
 						backdrop.style.transition = 'opacity 300ms ease-in';
 						content.style.transition = 'opacity 300ms ease-in, transform 300ms ease-in';
-						
+
 						// Animate out
 						backdrop.style.opacity = '0';
-						
+
 						if (position === 'left') {
 							content.style.transform = 'translateX(-100%)';
 						} else if (position === 'right') {
@@ -346,9 +348,9 @@ templ Script() {
 						} else if (position === 'bottom') {
 							content.style.transform = 'translateY(100%)';
 						}
-						
+
 						content.style.opacity = '0';
-						
+
 						// Hide elements after animation
 						setTimeout(() => {
 							if (content.style.opacity === '0') { // Check if it wasn't reopened during the timeout
@@ -362,7 +364,7 @@ templ Script() {
 							}
 						}, 300);
 					}
-					
+
 					// Click away handler
 					function handleClickAway(e) {
 						// Check if the click is outside the content AND not on any trigger associated with THIS drawer
@@ -372,32 +374,50 @@ templ Script() {
 							closeDrawer();
 						}
 					}
-					
+
 					// ESC key handler
 					function handleEscKey(e) {
 						if (e.key === 'Escape' && content.style.display === 'block') {
 							closeDrawer();
 						}
 					}
-					
+
 					// Set up trigger click listeners
-					triggers.forEach(trigger => {
-						trigger.removeEventListener('click', openDrawer); // Remove potential duplicates
-						trigger.addEventListener('click', openDrawer);
+					triggers.forEach((trigger, index) => {
+						// Remove all existing click listeners
+						const newTrigger = trigger.cloneNode(true);
+						trigger.parentNode.replaceChild(newTrigger, trigger);
+
+						// Add new click listener
+						newTrigger.addEventListener('click', (e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							openDrawer();
+						});
 					});
-					
+
 					// Set up close button listeners
-					closeButtons.forEach(button => {
-						button.removeEventListener('click', closeDrawer); // Remove potential duplicates
-						button.addEventListener('click', closeDrawer);
+					closeButtons.forEach((button, index) => {
+						// Remove all existing click listeners
+						const newButton = button.cloneNode(true);
+						button.parentNode.replaceChild(newButton, button);
+
+						// Add new click listener
+						newButton.addEventListener('click', (e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							closeDrawer();
+						});
 					});
-					
+
 					// Stop propagation on the inner content click to prevent backdrop click handler
 					const inner = content.querySelector('[data-drawer-inner]');
 					if (inner) {
 						inner.removeEventListener('click', stopPropagationHandler); // Remove potential duplicates
 						inner.addEventListener('click', stopPropagationHandler);
 					}
+
+					drawer.dataset.drawerInitialized = 'true';
 				}
 
 				function stopPropagationHandler(e) {
@@ -425,6 +445,12 @@ templ Script() {
 				document.addEventListener('DOMContentLoaded', () => initAllComponents());
 				document.body.addEventListener('htmx:afterSwap', handleHtmxSwap);
 				document.body.addEventListener('htmx:oobAfterSwap', handleHtmxSwap);
+				// Add popstate event listener for browser history navigation
+				window.addEventListener('popstate', () => {
+					requestAnimationFrame(() => {
+						initAllComponents(document);
+					});
+				});
 			})(); // End of IIFE
         </script>
 	}


### PR DESCRIPTION
When using htmx-swap, after a `history.back()` action, drawer trigger button is not initialized. This PR is to init events on `popstate` event.

Note: I had to close previous PR #162 and open this because of layout change.
