### PR TITLE
Switch math/rand to crypto/rand in RandomID()

### DIFF
--- a/internal/utils/templui.go
+++ b/internal/utils/templui.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 
-	"math/rand"
+	"crypto/rand"
 
 	"github.com/a-h/templ"
 
@@ -48,7 +48,7 @@ func MergeAttributes(attrs ...templ.Attributes) templ.Attributes {
 }
 
 // RandomID generates a random ID string.
-// Example: RandomID() → "id-123456"
+// Example: RandomID() → "id-1a2b3c"
 func RandomID() string {
-	return fmt.Sprintf("id-%d", rand.Intn(1000000))
+	return fmt.Sprintf("id-%s", rand.Text())
 }


### PR DESCRIPTION
Hi! I recently used the templui to download a component. When doing so, the `utils/templui.go` that was created threw an error running a pre-commit hook that uses [golangci-lint](https://github.com/golangci/golangci-lint):

```
utils/templui.go:54:30: G404: Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand) (gosec)
return fmt.Sprintf("id-%d", rand.Intn(1000000))
```

This updates the code to no longer throw that error.