### PR TITLE
Add hx-indicator prop on button

### DIFF
--- a/internal/components/button/button.templ
+++ b/internal/components/button/button.templ
@@ -47,6 +47,7 @@ type Props struct {
 	HxTarget     string
 	HxSwap       string
 	HxReplaceUrl string
+	HxIndicator  string
 }
 
 templ Button(props ...Props) {
@@ -125,6 +126,9 @@ templ Button(props ...Props) {
 			}
 			if p.HxReplaceUrl != "" {
 				hx-replace-url={ p.HxReplaceUrl }
+			}
+			if p.HxIndicator != "" {
+				hx-indicator={ p.HxIndicator }
 			}
 			{ p.Attributes... }
 		>


### PR DESCRIPTION
I find it often practical to be able to set the `hx-indicator` tag on some buttons. Currently, we'd have to write something like this:

```go
templ NewOTPButton() {
	@button.Button(button.Props{
		Attributes: templ.Attributes{"hx-indicator": "this"},
		Type:       button.TypeButton,
		Variant:    button.VariantGhost,
		Class:      "flex flex-row gap-2",
		HxPost:     "/login/otp/new",
	}) {
		@spinner.Spinner(spinner.Props{Size: spinner.SizeSm, Class: "htmx-indicator"})
		Send a new code
	}
}
```


<details><summary>Full Context</summary>

```go
templ LoginOTPForm() {
    <form
    	class="flex flex-col gap-4"
    	hx-post="/login/otp"
    	hx-indicator="#login-spinner"
    >
    	<input type="hidden" name="email" value={ email }/>
    	@form.Item() {
    		@label.Label(label.Props{
    			For: "otp-with-label",
    		}) {
    			OTP Code
    		}
    		@inputotp.InputOTP(inputotp.Props{
    			Class:    "w-full",
    			ID:       "otp-with-label",
    			Name:     "otp",
    			Required: true,
    			HasError: err.otp != "",
    		}) {
    			@inputotp.Group(inputotp.GroupProps{Class: "w-full flex flex-row justify-center"}) {
    				@inputotp.Slot(inputotp.SlotProps{Index: 0})
    				@inputotp.Slot(inputotp.SlotProps{Index: 1})
    				@inputotp.Slot(inputotp.SlotProps{Index: 2})
    				@inputotp.Slot(inputotp.SlotProps{Index: 3})
    				@inputotp.Slot(inputotp.SlotProps{Index: 4})
    				@inputotp.Slot(inputotp.SlotProps{Index: 5})
    			}
    			if err.otp != "" {
    				@form.Message(form.MessageProps{Variant: form.MessageVariantError}) {
    					{ err.otp }
    				}
    			}
    		}
    	}
    	@button.Button(button.Props{
    		Type:  button.TypeSubmit,
    		Class: "flex flex-row gap-2",
    	}) {
    		@spinner.Spinner(spinner.Props{
    			Size:  spinner.SizeSm,
    			Color: "text-primary-foreground",
    			ID:    "login-spinner",
    			Class: "htmx-indicator",
    		})
    		Connect
    	}
    	@NewOTPButton()
    </form>
}

templ NewOTPButton() {
	@button.Button(button.Props{
		Attributes: templ.Attributes{"hx-indicator": "this"},
		Type:       button.TypeButton,
		Variant:    button.VariantGhost,
		Class:      "flex flex-row gap-2",
		HxPost:     "/login/otp/new",
	}) {
		@spinner.Spinner(spinner.Props{Size: spinner.SizeSm, Class: "htmx-indicator"})
		Send a new code
	}
}
```
<p>In this case, we want two different spinners to react to different HTMX POST requests, which is why we need to specify the ID of the elements. If we didn't, both buttons would have a spinner while the form is being sent, for example.

![Screenshot 2025-06-03 at 09 46 36](https://github.com/user-attachments/assets/cefb7651-16d8-4be5-afca-14cb53574206)

![Screenshot 2025-06-03 at 09 46 57](https://github.com/user-attachments/assets/f66a0b40-cf9a-442d-b875-33bccbbc9e03)


</details> 



By merging this PR, we could rewrite like so:
```go
templ NewOTPButton() {
	@button.Button(button.Props{
		Type:        button.TypeButton,
		Variant:     button.VariantGhost,
		Class:       "flex flex-row gap-2",
		HxPost:      "/login/otp/new",
		HxIndicator: "this",
	}) {
		@spinner.Spinner(spinner.Props{Size: spinner.SizeSm, Class: "htmx-indicator"})
		Send a new code
	}
}
```

Which feels more like the rest of the library.

What do you think @axzilla ?