### PR TITLE
let form description take a value

### DIFF
--- a/internal/components/form/form.templ
+++ b/internal/components/form/form.templ
@@ -29,6 +29,7 @@ type LabelProps struct {
 type DescriptionProps struct {
 	ID         string
 	Class      string
+	Value	   any
 	Attributes templ.Attributes
 }
 
@@ -98,6 +99,9 @@ templ Description(props ...DescriptionProps) {
 		class={ utils.TwMerge("text-sm text-muted-foreground", p.Class) }
 		{ p.Attributes... }
 	>
+		if p.Value != nil {
+			{ p.Value }
+		}
 		{ children... }
 	</p>
 }


### PR DESCRIPTION
this came out of a need to perform a `hx-swap` on a form description, but not being to edit the form description value from the corresponding response from go