### PR TITLE
Fix form component docs: Fixed select box href

### DIFF
--- a/internal/ui/pages/form.templ
+++ b/internal/ui/pages/form.templ
@@ -75,7 +75,7 @@ templ Form() {
 								<a href="/docs/components/radio#form" class="font-medium hover:underline">Radio</a>
 							</li>
 							<li>
-								<a href="/docs/components/select#form" class="font-medium hover:underline">Select</a>
+								<a href="/docs/components/select-box#form" class="font-medium hover:underline">Select Box</a>
 							</li>
 							<li>
 								<a href="/docs/components/textarea#form" class="font-medium hover:underline">Textarea</a>


### PR DESCRIPTION
Fix `select box` reference in `form` component documentation.