### PR TITLE
Remove a dash from ---accent-foreground variable.

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -16,7 +16,7 @@
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
-  --color-accent-foreground: var(---accent-foreground);
+  --color-accent-foreground: var(--accent-foreground);
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
   --color-card: var(--card);

--- a/internal/ui/pages/how_to_use.templ
+++ b/internal/ui/pages/how_to_use.templ
@@ -68,7 +68,7 @@ var inputCss = `@import 'tailwindcss';
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
-  --color-accent-foreground: var(---accent-foreground);
+  --color-accent-foreground: var(--accent-foreground);
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
   --color-card: var(--card);


### PR DESCRIPTION
Fixes what looks like a typo in the variable --accent-foreground in input.css, both in the assets file and where it's displayed in the how-to-use page.